### PR TITLE
Fix: Centralize Device Restrictions for Therapy Activities

### DIFF
--- a/src/components/DeviceRestriction.tsx
+++ b/src/components/DeviceRestriction.tsx
@@ -6,14 +6,15 @@ interface DeviceRestrictionProps {
 }
 
 const DeviceRestriction: React.FC<DeviceRestrictionProps> = ({ children }) => {
-  const [isMobile, setIsMobile] = useState(false);
+  const [isMobile, setIsMobile] = useState(() => 
+    typeof window !== 'undefined' ? window.innerWidth < 768 : false
+  );
 
   useEffect(() => {
     const checkSize = () => {
       setIsMobile(window.innerWidth < 768);
     };
     
-    checkSize();
     window.addEventListener('resize', checkSize);
     return () => window.removeEventListener('resize', checkSize);
   }, []);

--- a/src/components/exercises/CharacterHunt.tsx
+++ b/src/components/exercises/CharacterHunt.tsx
@@ -2,7 +2,6 @@ import { useState, useCallback, useRef } from 'react';
 import { useSnackbar } from '../../hooks/Snackbar';
 import AnaglyphWrapper, { RedEye, CyanEye } from '../games/AnaglyphWrapper';
 import ExerciseTimer from './ExerciseTimer';
-import DeviceRestriction from '../DeviceRestriction';
 
 interface CharacterHuntProps {
   onComplete?: (score: number) => void;
@@ -89,76 +88,74 @@ export default function CharacterHunt({ onComplete }: CharacterHuntProps) {
   };
 
   return (
-    <DeviceRestriction>
-      <div className="flex flex-col items-center w-full h-full p-2 bg-purple-50/30 overflow-hidden" ref={containerRef}>
-        {!isActive ? (
-          <div className="flex-1 flex flex-col items-center justify-center w-full">
-            <div className="bg-white p-10 rounded-[3rem] shadow-2xl border-4 border-purple-100 text-center max-w-xl animate-in zoom-in duration-500">
-              <h3 className="text-4xl font-black mb-4 uppercase tracking-widest text-purple-900">Character Hunt</h3>
-              <p className="mb-8 text-lg text-gray-700 text-center px-6">
-                Put on your **Red-Blue glasses**! <br/>
-                Find the target character in the grid as fast as you can.
-              </p>
-              <button 
-                onClick={startExercise} 
-                className="px-16 py-4 bg-purple-600 hover:bg-purple-500 text-white text-xl font-black rounded-3xl shadow-xl transition-all transform hover:scale-105 active:scale-95"
-              >
-                Start Mission
-              </button>
-            </div>
+    <div className="flex flex-col items-center w-full h-full p-2 bg-purple-50/30 overflow-hidden" ref={containerRef}>
+      {!isActive ? (
+        <div className="flex-1 flex flex-col items-center justify-center w-full">
+          <div className="bg-white p-10 rounded-[3rem] shadow-2xl border-4 border-purple-100 text-center max-w-xl animate-in zoom-in duration-500">
+            <h3 className="text-4xl font-black mb-4 uppercase tracking-widest text-purple-900">Character Hunt</h3>
+            <p className="mb-8 text-lg text-gray-700 text-center px-6">
+              Put on your **Red-Blue glasses**! <br/>
+              Find the target character in the grid as fast as you can.
+            </p>
+            <button 
+              onClick={startExercise} 
+              className="px-16 py-4 bg-purple-600 hover:bg-purple-500 text-white text-xl font-black rounded-3xl shadow-xl transition-all transform hover:scale-105 active:scale-95"
+            >
+              Start Mission
+            </button>
           </div>
-        ) : (
-          <div className="w-full h-full flex flex-col items-center gap-4 relative py-4">
-            <div className="flex justify-between w-full max-w-6xl items-center px-8">
-              <div className="flex flex-col bg-white px-4 py-2 rounded-2xl border-2 border-purple-200 shadow-md">
-                <span className="text-[10px] font-black text-gray-500 uppercase tracking-widest">Find Target</span>
-                <span className="text-4xl font-black text-purple-900 leading-none">{targetChar}</span>
+        </div>
+      ) : (
+        <div className="w-full h-full flex flex-col items-center gap-4 relative py-4">
+          <div className="flex justify-between w-full max-w-6xl items-center px-8">
+            <div className="flex flex-col bg-white px-4 py-2 rounded-2xl border-2 border-purple-200 shadow-md">
+              <span className="text-[10px] font-black text-gray-500 uppercase tracking-widest">Find Target</span>
+              <span className="text-4xl font-black text-purple-900 leading-none">{targetChar}</span>
+            </div>
+            <div className="flex items-center gap-6">
+              <div className="bg-white px-6 py-2 rounded-2xl border-2 border-purple-200 shadow-md">
+                <span className="text-xl font-black text-blue-600 uppercase tracking-tighter">XP: {score}</span>
               </div>
-              <div className="flex items-center gap-6">
-                <div className="bg-white px-6 py-2 rounded-2xl border-2 border-purple-200 shadow-md">
-                  <span className="text-xl font-black text-blue-600 uppercase tracking-tighter">XP: {score}</span>
-                </div>
-                <div className="scale-75 origin-right">
-                  <ExerciseTimer initialDuration={120} onComplete={handleFinish} />
-                </div>
+              <div className="scale-75 origin-right">
+                <ExerciseTimer initialDuration={120} onComplete={handleFinish} />
               </div>
             </div>
-
-            <div className="relative w-full flex-1 max-w-6xl bg-white rounded-[3rem] border-8 border-purple-100 shadow-2xl overflow-hidden mx-4">
-              <AnaglyphWrapper>
-                <div className="grid grid-cols-6 md:grid-cols-8 gap-4 p-8 h-full items-stretch">
-                  {grid.map((item, i) => {
-                    const Button = (
-                      <button
-                        onClick={() => handleCharClick(item.char)}
-                        className={`w-full h-full flex items-center justify-center text-4xl font-black rounded-[2rem] border-4 transition-all active:scale-90 shadow-lg
-                          ${item.eye === 'red' 
-                            ? 'bg-red-500 border-red-700 text-black shadow-red-200' 
-                            : 'bg-cyan-500 border-cyan-700 text-black shadow-cyan-200'}
-                        `}
-                      >
-                        {item.char}
-                      </button>
-                    );
-
-                    return item.eye === 'red' ? (
-                      <RedEye key={i} className="h-full">{Button}</RedEye>
-                    ) : (
-                      <CyanEye key={i} className="h-full">{Button}</CyanEye>
-                    );
-                  })}
-                </div>
-              </AnaglyphWrapper>
-            </div>
-
-            <div className="bg-white px-8 py-3 rounded-2xl border-2 border-purple-100 max-w-lg text-center shadow-lg">
-              <p className="text-black text-xs font-black uppercase tracking-widest">
-                Red = Right Eye | Blue = Left Eye. Use both to hunt!
-              </p>
-            </div>
           </div>
-        )}
-      </div>
-    </DeviceRestriction>
+
+          <div className="relative w-full flex-1 max-w-6xl bg-white rounded-[3rem] border-8 border-purple-100 shadow-2xl overflow-hidden mx-4">
+            <AnaglyphWrapper>
+              <div className="grid grid-cols-6 md:grid-cols-8 gap-4 p-8 h-full items-stretch">
+                {grid.map((item, i) => {
+                  const Button = (
+                    <button
+                      onClick={() => handleCharClick(item.char)}
+                      className={`w-full h-full flex items-center justify-center text-4xl font-black rounded-[2rem] border-4 transition-all active:scale-90 shadow-lg
+                        ${item.eye === 'red' 
+                          ? 'bg-red-500 border-red-700 text-black shadow-red-200' 
+                          : 'bg-cyan-500 border-cyan-700 text-black shadow-cyan-200'}
+                      `}
+                    >
+                      {item.char}
+                    </button>
+                  );
+
+                  return item.eye === 'red' ? (
+                    <RedEye key={i} className="h-full">{Button}</RedEye>
+                  ) : (
+                    <CyanEye key={i} className="h-full">{Button}</CyanEye>
+                  );
+                })}
+              </div>
+            </AnaglyphWrapper>
+          </div>
+
+          <div className="bg-white px-8 py-3 rounded-2xl border-2 border-purple-100 max-w-lg text-center shadow-lg">
+            <p className="text-black text-xs font-black uppercase tracking-widest">
+              Red = Right Eye | Blue = Left Eye. Use both to hunt!
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/pages/TherapyPage.tsx
+++ b/src/pages/TherapyPage.tsx
@@ -14,10 +14,12 @@ import AnaglyphSnake from "../components/games/AnaglyphSnake";
 import AnaglyphHiddenPicture from "../components/games/AnaglyphHiddenPicture";
 import AnaglyphMaze from "../components/games/AnaglyphMaze";
 import BrockString from "../components/exercises/BrockString";
+import DeviceRestriction from "../components/DeviceRestriction";
 
 export default function TherapyPage() {
   const location = useLocation();
   const isBaseTherapy = location.pathname === "/therapy";
+  const isPatching = location.pathname.includes("/patching");
 
   const exercises = [
     { 
@@ -241,9 +243,3 @@ export function AnaglyphSnakePage() {
 export function BrockStringPage() {
   return <BrockString />;
 }
-
-
-
-
-
-

--- a/src/pages/TherapyPage.tsx
+++ b/src/pages/TherapyPage.tsx
@@ -102,7 +102,13 @@ export default function TherapyPage() {
             <FaArrowLeft /> Back to Therapy Center
           </Link>
           <div className="bg-gray-50/50 rounded-3xl flex flex-col items-stretch border-4 border-dashed border-gray-100 min-h-[60vh]">
-            <Outlet />
+            {isPatching ? (
+              <Outlet />
+            ) : (
+              <DeviceRestriction>
+                <Outlet />
+              </DeviceRestriction>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
### Problem
Games and exercises were still accessible on mobile devices despite previous restriction attempts. This was due to:
- Restrictions only being applied locally in \CharacterHunt.tsx\.
- Missing global layout restrictions in \TherapyPage.tsx\.
- A race condition in \DeviceRestriction.tsx\ where \isMobile\ defaulted to \alse\.

### Solution
- **Centralized Restrictions:** Wrapped the \Outlet\ in \TherapyPage.tsx\ with \DeviceRestriction\ for all therapy routes except \patching\.
- **Improved Detection:** Initialized \isMobile\ in \DeviceRestriction.tsx\ using current \window.innerWidth\ to prevent bypass during initial mount.
- **Refactoring:** Removed redundant local \DeviceRestriction\ from \CharacterHunt.tsx\.

### Impact
Consistent clinical compliance across all therapy activities on mobile devices.